### PR TITLE
Implement ID store, covert id subcommand, forward secrecy and new CLI…

### DIFF
--- a/covert/__main__.py
+++ b/covert/__main__.py
@@ -1,106 +1,18 @@
 import os
 import sys
 from typing import NoReturn
+
 import colorama
-import covert
-from covert.cli import main_benchmark, main_dec, main_edit, main_enc
 
-basicusage = """\
-Usage:
-  covert enc [files] [recipients] [signatures] [-A | -o unsuspicious.dat [-a]]
-  covert dec [-A | unsuspicious.dat] [-i id_ed25519] [-o filesfolder]
-  covert edit unsuspicious.dat — change text in a passphrase-protected archive
-"""
+from covert.cli import main_benchmark, main_dec, main_edit, main_enc, main_id
+from covert.clihelp import print_help, print_version
 
-shorthdrhelp = f"""\
-{basicusage}\
-  covert help — show full command line help
-
-Running covert enc/dec without arguments asks for a password and a message.
-Files and folders get attached together with a message if 'enc -' is specified.
-"""
-
-# Short command line help
-shortenchelp = """\
-  -p                Passphrase recipient (default)
-  --wide-open       Anyone can open the file (no recipients)
-  -r PKEY -R FILE   Recipient pubkey, .pub file or github:username
-  -i SKEY           Sign with a secret key (string token or id file)
-  -A                Auto copy&paste: ciphertext is copied
-  -o FILENAME       Encrypted file to output (binary unless -a is used)
-  --pad PERCENT     Preferred padding amount (default 5 %)
-"""
-
-shortdechelp = """\
-  -A                Auto copy&paste: ciphertext is pasted
-  -i SKEY           Decrypt with secret key (token or file)
-  -o FILEFOLDER     Extract any attached files to
-"""
-
-introduction = f"""\
-Covert {covert.__version__} - A file and message encryptor with strong anonymity
- 💣  Things encrypted with this developer preview mayn't be readable evermore
-"""
-
-shortcmdhelp = f"""\
-{introduction}
-{shorthdrhelp}
-{shortenchelp}
-{shortdechelp}
-"""
-
-# Full command line help
-hdrhelp = f"""\
-{basicusage}\
-  covert help — show full command line help
-  covert benchmark — run a performance benchmark for decryption and encryption
-
-Running covert enc/dec without arguments asks for a password and a message.
-Files and folders get attached together with a message if 'enc -' is specified.
-"""
-
-enchelp = f"""\
-Encryption options:
-{shortenchelp}\
-  -a                Write base64 encoded output when -o is used
-"""
-
-dechelp = f"""\
-Decryption options:
-{shortdechelp}\
-"""
-
-keyformatshelp = """\
-Supported key formats:
-
-* age1: To generate a key, run: age-keygen
-* ssh-ed25519: To generate a key, run: ssh-keygen -t ed25519
-"""
-
-exampleshelp = """\
-Examples:
-
-* To encrypt a message using an ssh-ed25519 public key, run:
-  - covert enc -R ~/.ssh/myfriend.pub -o file
-  - covert enc -r "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL1hd2CrH/pexUjxNfqhHAaKqGwSmn0+sO/YUXVm9Gt1" -o file
-
-* To decrypt a message using a private ssh-ed25519 key file, run:
-  - covert dec -i ~/.ssh/id_ed25519 file
-"""
-
-cmdhelp = f"""\
-{introduction}
-{hdrhelp}
-{enchelp}
-{dechelp}
-{keyformatshelp}
-{exampleshelp}
-"""
 
 class Args:
 
   def __init__(self):
     self.mode = None
+    self.idname = ""
     self.files = []
     self.wideopen = None
     self.askpass = 0
@@ -113,9 +25,13 @@ class Args:
     self.armor = None
     self.paste = None
     self.debug = None
+    self.delete_entire_idstore = False
+    self.delete = False
+    self.secret = False
 
 
 encargs = dict(
+  idname='-I --id'.split(),
   askpass='-p --passphrase'.split(),
   passwords='--password'.split(),
   wideopen='--wide-open'.split(),
@@ -130,11 +46,23 @@ encargs = dict(
 )
 
 decargs = dict(
+  idname='-I --id'.split(),
   askpass='-p --passphrase'.split(),
   passwords='--password'.split(),
   identities='-i --identity'.split(),
   outfile='-o --out --output'.split(),
   paste='-A'.split(),
+  debug='--debug'.split(),
+)
+
+idargs = dict(
+  askpass='-p --passphrase'.split(),
+  recipients='-r --recipient'.split(),
+  recipfiles='-R --keyfile --recipients-file'.split(),
+  identities='-i --identity'.split(),
+  secret='-s --secret'.split(),
+  delete_entire_idstore='--delete-entire-idstore'.split(),
+  delete='-D --delete'.split(),
   debug='--debug'.split(),
 )
 
@@ -146,19 +74,9 @@ modes = {
   "enc": main_enc,
   "dec": main_dec,
   "edit": main_edit,
+  "id": main_id,
   "benchmark": main_benchmark,
 }
-
-def print_help(modehelp: str = None):
-  if modehelp is None:
-    modehelp = shortcmdhelp
-  first, rest = modehelp.rstrip().split('\n', 1)
-  print(f'\x1B[1;44m{first:78}\x1B[0m\n{rest}')
-  sys.exit(0)
-
-def print_version():
-  print(shortcmdhelp.split('\n')[0])
-  sys.exit(0)
 
 def needhelp(av):
   """Check for -h and --help but not past --"""
@@ -166,6 +84,15 @@ def needhelp(av):
     if a == '--': return False
     if a.lower() in ('-h', '--help'): return True
   return False
+
+def subcommand(arg):
+  if arg in ('enc', 'encrypt', '-e'): return 'enc', encargs
+  if arg in ('dec', 'decrypt', '-d'): return 'dec', decargs
+  if arg in ('edit'): return 'edit', editargs
+  if arg in ('id'): return 'id', idargs
+  if arg in ('bench', 'benchmark'): return 'benchmark', benchargs
+  if arg in ('help', ): return 'help', {}
+  return None, {}
 
 def argparse():
   # Custom parsing due to argparse module's limitations
@@ -176,31 +103,21 @@ def argparse():
   if any(a.lower() in ('-v', '--version') for a in av):
     print_version()
 
-  ad = {}
   args = Args()
-  modehelp = None
   # Separate mode selector from other arguments
   if av[0].startswith("-") and len(av[0]) > 2 and not needhelp(av):
       av.insert(1, f'-{av[0][2:]}')
       av[0] = av[0][:2]
 
-  # Support a few other forms for Age etc. compatibility (but only as the first arg)
-  if av[0] in ('enc', 'encrypt', '-e'):
-    args.mode, ad, modehelp = 'enc', encargs, f"{hdrhelp}\n{enchelp}"
-  elif av[0] in ('dec', 'decrypt', '-d'):
-    args.mode, ad, modehelp = 'dec', decargs, f"{hdrhelp}\n{dechelp}"
-  elif av[0] in ('edit', ):
-    args.mode, ad, modehelp = 'edit', editargs, hdrhelp
-  elif av[0] in ('bench', 'benchmark'):
-    args.mode, ad, modehelp = 'benchmark', benchargs, hdrhelp
-  elif av[0] in ('help', ):
-    args.mode, ad, modehelp = 'help', {}, cmdhelp
+  args.mode, ad = subcommand(av[0])
 
   if args.mode == 'help' or needhelp(av):
-    print_help(modehelp=modehelp)
+    if args.mode == 'help' and len(av) == 2 and (mode := subcommand(av[1])[0]):
+      print_help(mode)
+    print_help(args.mode or "help")
 
   if args.mode is None:
-    sys.stderr.write(' 💣  Invalid or missing command (enc/dec/edit/benchmark/help).\n')
+    sys.stderr.write(' 💣  Invalid or missing command (enc/dec/edit/id/benchmark/help).\n')
     sys.exit(1)
 
   aiter = iter(av[1:])
@@ -222,8 +139,7 @@ def argparse():
     if not a.startswith('--') and len(a) > 2:
       if any(arg not in shortargs for arg in list(a[1:])):
         falseargs = [arg for arg in list(a[1:]) if arg not in shortargs]
-        sys.stderr.write(f' 💣  {falseargs} is not an argument: covert {args.mode} {a}\n')
-        sys.exit(1)
+        print_help(args.mode, f' 💣  Unknown argument: covert {args.mode} {a} (failing -{" -".join(falseargs)})')
       a = [f'-{shortarg}' for shortarg in list(a[1:]) if shortarg in shortargs]
     if isinstance(a, str):
       a = [a]
@@ -232,8 +148,7 @@ def argparse():
       if isinstance(av, int):
         continue
       if argvar is None:
-        sys.stderr.write(f'{modehelp}\n 💣  Unknown argument: covert {args.mode} {aprint}\n')
-        sys.exit(1)
+        print_help(args.mode, f' 💣  Unknown argument: covert {args.mode} {aprint}')
       try:
         var = getattr(args, argvar)
         if isinstance(var, list):
@@ -245,8 +160,7 @@ def argparse():
         else:
           setattr(args, argvar, True)
       except StopIteration:
-        sys.stderr.write(f'{modehelp}\n 💣  Argument parameter missing: covert {args.mode} {aprint} …\n')
-        sys.exit(1)
+        print_help(args.mode, f' 💣  Argument parameter missing: covert {args.mode} {aprint} …')
 
   return args
 

--- a/covert/blockstream.py
+++ b/covert/blockstream.py
@@ -2,13 +2,13 @@ import collections
 import mmap
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from hashlib import sha512
 from secrets import token_bytes
 
 from nacl.exceptions import CryptoError
 
-from covert import chacha, pubkey
+from covert import chacha, pubkey, ratchet
 from covert.cryptoheader import Header, encrypt_header
 from covert.elliptic import xed_sign, xed_verify
 from covert.util import noncegen
@@ -17,14 +17,16 @@ BS = (1 << 20) - 19  # The maximum block size to use
 
 def decrypt_file(auth, f, archive):
   b = BlockStream()
-  b.decrypt_init(f)
-  if not b.header.key:
-    for a in auth:
-      with suppress(CryptoError):
-        b.authenticate(a)
-        break
-  yield from b.decrypt_blocks()
-  b.verify_signatures(archive)
+  with b.decrypt_init(f):
+    if not b.header.key:
+      for a in auth:
+        with suppress(CryptoError):
+          b.authenticate(a)
+          break
+      # In case auth is a generator, close it immediately (otherwise would be delayed)
+      if hasattr(auth, "close"): auth.close()
+    yield from b.decrypt_blocks()
+    b.verify_signatures(archive)
 
 class BlockStream:
   def __init__(self):
@@ -33,17 +35,23 @@ class BlockStream:
     self.workers = 8
     self.executor = ThreadPoolExecutor(max_workers=self.workers)
     self.blkhash = None
+    self.file = None
     self.ciphertext = None
     self.q = collections.deque()
     self.pos = 0  # Current position within self.ciphertext; queued for decryption, not decoded
+    self.end = 0
+
 
   def authenticate(self, anykey):
     """Attempt decryption using secret key or password hash"""
-    if isinstance(anykey, pubkey.Key):
+    if isinstance(anykey, ratchet.Ratchet):
+      self.header.try_ratchet(anykey)
+    elif isinstance(anykey, pubkey.Key):
       self.header.try_key(anykey)
     else:
       self.header.try_pass(anykey)
 
+  @contextmanager
   def decrypt_init(self, f):
     self.pos = 0
     if hasattr(f, "__len__"):
@@ -58,6 +66,14 @@ class BlockStream:
       self.end = 0
     size = self._read(1024)
     self.header = Header(self.ciphertext[:size])
+    try:
+      yield
+    finally:
+      self.ciphertext.release()
+      self.ciphertext = None
+      self.file = None
+      self.pos = self.end = 0
+
 
   def _add_to_queue(self, p, extlen, aad=None):
     pos, end = p, p + extlen
@@ -140,7 +156,7 @@ class BlockStream:
     a.signatures = []
     # Signature verification
     if a.index.get('s'):
-      signatures = [pubkey.Key(edpk=k) for k in a.index['s']]
+      signatures = [pubkey.Key(pk=k) for k in a.index['s']]
       for key in signatures:
         sz = self._read(self.end - self.pos + 80)
         if sz < 80:
@@ -156,7 +172,7 @@ class BlockStream:
           continue
         try:
           xed_verify(key.pk, self.blkhash, signature)
-          a.signatures.append((True, key, 'Signature verified'))
+          a.signatures.append((True, key, 'Signed by'))
         except CryptoError:
           a.signatures.append((False, key, 'Forged signature'))
 

--- a/covert/clihelp.py
+++ b/covert/clihelp.py
@@ -1,0 +1,169 @@
+import sys
+from typing import NoReturn
+
+import covert
+
+T = "\x1B[1;44m"  # titlebar (white on blue)
+H = "\x1B[1;37m"  # heading (bright white)
+C = "\x1B[0;34m"  # command (dark blue)
+F = "\x1B[1;34m"  # flag (light blue)
+D = "\x1B[1;30m"  # dark / syntax markup
+N = "\x1B[0m"     # normal color
+
+usage = dict(
+  enc=f"""\
+{C}covert {F}enc --id{N} you:them {D}[{N}{F}-r{N} pubkey {D}|{N} {F}-R{N} pkfile{D}]  ⋯{N}
+{C}covert {F}enc {D}[{F}-i {N}id.key{D}] [{F}-r {N}pubkey {D}|{N} {F}-R {N}pkfile {D}|{F} -p {D}|{F} --wide-open{D}]…  ⋯
+        ⋯  [{F}--pad {N}5{D}] [{F}-A {D}| [{F}-o {N}cipher.dat {D}[{F}-a{D}]] [{N}file.jpg{D}]…{N}
+""",
+  dec=f"{C}covert {F}dec {D}[{F}--id {N}you:them{D}] [{F}-i {N}id.key{D}] [{F}-A {D}|{N} cipher.dat{D}] [{F}-o {N}files/{D}]{N}\n",
+  id=f"{C}covert {F}id {D}[{N}you:them{D}] [{N}options{D}] —{N} create/manage ID store of your keys\n",
+  edit=f"{C}covert {F}edit {N}cipher.dat {D}—{N} securely keep notes with passphrase protection\n",
+  bench=f"{C}covert {F}benchmark {D}—{N} run a performance benchmark for decryption and encryption\n",
+)
+
+usagetext = dict(
+  enc=f"""\
+Encrypt a message and/or files. The first form uses ID store, while the second
+does not and instead takes all keys on the command line. When no files are
+given or {F}-{N} is included, Covert asks for message input or reads stdin.
+
+  {F}--id {N}alice:bob    Use ID store for local (alice) and peer (bob) keys
+  {F}-i {N}seckey         Sign the message with your secret key
+  {F}-r {N}pubkey {F}-R{N} file Encrypt the message for this public key
+  {F}-p{N}                Passphrase encryption (default when no other options)
+  {F}--wide-open{N}       Allow anyone to open the file (no keys or passphrase)
+
+  {F}--pad{N} PERCENT     Preferred random padding amount (default 5 %)
+  {F}-o{N} FILENAME       Output file (binary ciphertext that looks entirely random)
+  {F}-a{N}                ASCII/text output (default for terminal/clipboard)
+  {F}-A{N}                Auto copy&paste of ciphertext (desktop use)
+
+With ID store, no keys need to be defined on command line, although as a
+shortcut one may store a new peer by specifiying a previously unused peer name
+and his public key by {C}covert {F}enc --id {N}you:newpeer{F} -r{N} key {D}⋯{N}  avoiding the use
+of the {F}id{N} subcommand to add the peer public key first. Conversations already
+established use forward secret keys and should have no key specified on {F}enc{N}.
+
+Folders may be specified as input files and they will be stored recursively.
+Any paths given on command line are stripped off the stored names, such that
+each item appears at archive root, avoiding accidental leakage of metadata.
+""",
+  dec=f"""\
+Decrypt Covert archive. Tries decryption with options given on command line,
+and with all conversations and keys stored in ID store.
+
+  {F}--id {N}alice:bob    Store the sender as "bob" if not previously known
+  {F}-i {N}seckey         Sign the message with your secret key
+  {F}-r {N}pubkey {F}-R{N} file Encrypt the message for this public key
+  {F}-p{N}                Passphrase encryption (default when no other options)
+  {F}--wide-open{N}       Allow anyone to open the file (no keys or passphrase)
+  {F}-o{N} folder         Folder where to extract any attached files.
+  {F}-A{N}                Auto copy&paste of ciphertext (desktop use)
+""",
+  edit=f"""\
+Avoids having to extract the message in plain text for editing, which could
+leave copies on disk unprotected. Use {C}covert {F}enc{N} with a passphrase to create
+the initial archive. Attached files and other data are preserved even though
+editing overwrites the entire encrypted file.
+""",
+  id=f"""\
+The ID store keeps your encryption keys stored securely and enables messaging
+with forward secrecy. You only need to enter anyone's public key the first
+time you send them a message and afterwards all replies use temporary keys
+which change with each message sent and received.
+
+  {F}-s --secret{N}       Show secret keys (by default only shows public keys)
+  {F}-p --passphrase{N}   Change Master ID passphrase
+  {F}-r {N}pk {F}-R {N}pkfile   Change/set the public key associated with ID local:peer
+  {F}-i {N}seckey         Change the secret key of the given local ID
+  {F}-D --delete{N}       Delete the ID (local and all its peers, or the given peer)
+  {F}--delete-entire-idstore{N}  Securely erase the entire ID storage
+
+The storage is created when you run {C}covert {F}id{N} yourname. Be sure to
+write down the master passphrase created or change it to one you can remember.
+Multiple local IDs can be created for separating one's different tasks and
+their contacts, but all share the same master passphrase.
+
+The ID names are for your own information and are never included in messages.
+Avoid using spaces or punctuation on them. Notice that your local ID always
+comes first, and any peer is separated by a colon. Deletion of a local ID also
+removes all public keys and conversations attached to it.
+""",
+)
+
+cmdhelp = {k: f"{usage[k]}\n{usagetext.get(k, '')}".rstrip("\n") + "\n" for k in usage}
+
+introduction = f"Covert {covert.__version__} - A file and message encryptor with strong anonymity"
+if len(introduction) > 78:  # git version string is too long
+  introduction = f"Covert {covert.__version__} - A file and message encryptor"
+
+introduction = f"""\
+{T}{introduction:78}{N}
+ 💣  Things encrypted with this developer preview mayn't be readable evermore
+"""
+
+shorthelp = f"""\
+{introduction}
+{"".join(usage.values())}
+Getting started: optionally create an ID ({C}covert {F}id{N} yourname), then use the
+{F}enc{N} command to send messages and {F}dec{N} to receive them. You won't need most
+of the options but see the help for more info. Commonly used options:
+
+  {F}--id {N}alice:bob    Use ID store for local (alice) and peer (bob) keys
+  {F}-i {N}seckey         Your secret key file (e.g .ssh/id_ed25519) or keystring
+  {F}-r {N}pubkey {F}-R{N} file Their public key, or {F}-R{N} github:username {D}|{N} bob.pub
+  {F}-A{N}                Auto copy&paste of ciphertext (desktop use)
+  {F}--help --version{N}  Useful information. Help applies to subcommands too.
+"""
+
+keyformatshelp = f"""\
+{H}Supported key formats and commands to generate keys:{N}
+
+* Age:         {C}covert {F}id{N} yourname      (Covert natively uses Age's key format)
+* Minisign:    {C}minisign {F}-R{N}
+* SSH ed25519: {C}ssh-keygen {F}-t ed25519{N}   (other SSH key types are not supported)
+* WireGuard:   {C}wg {F}genkey {C}| tee {N}secret.key {C}| wg {F}pubkey{N}
+"""
+
+exampleshelp = f"""\
+{H}Examples:{N}
+
+* To encrypt a message using an ssh-ed25519 public key, run:
+  - {C}covert {F}enc -R {N}github:myfriend {F}-o{N} file
+  - {C}covert {F}enc -R {N}~/.ssh/myfriend.pub {F}-o{N} file
+  - {C}covert {F}enc -r {N}AAAAC3NzaC1lZDI1NTE5AAAA... {F}-o{N} file
+
+* To decrypt a message using a private ssh-ed25519 key file, run:
+  - {C}covert {F}dec -i {N}~/.ssh/id_ed25519 file
+
+* Messaging and key storage with ID store:
+  - {C}covert {F}id {N}alice                      Add your ID (generate new or {F}-i{N} key)
+  - {C}covert {F}id {N}alice:bob {F}-R{N} github:bob    Add bob as a peer for local ID alice
+  - {C}covert {F}enc --id {N}alice:bob            Encrypt a message using idstore
+  - {C}covert {F}enc --id {N}alice:charlie {F}-r{N} pk  Adding a peer (on initial message)
+  - {C}covert {F}dec{N}                           Uses idstore for decryption
+"""
+
+allcommands = '\n\n'.join(cmdhelp.values())
+
+fullhelp = f"""\
+{introduction}
+{allcommands}
+
+{keyformatshelp}
+{exampleshelp}"""
+
+def print_help(modehelp: str = None, error: str = None) -> NoReturn:
+  stream = sys.stderr if error else sys.stdout
+  if modehelp is None: stream.write(shorthelp)
+  elif (h := cmdhelp.get(modehelp)): stream.write(h)
+  else: stream.write(fullhelp)
+  if error:
+    stream.write(f"\n{error}\n")
+    sys.exit(1)
+  sys.exit(0)
+
+def print_version() -> NoReturn:
+  print(f"Covert {covert.__version__}")
+  sys.exit(0)

--- a/covert/idstore.py
+++ b/covert/idstore.py
@@ -1,0 +1,160 @@
+import mmap
+import os
+from contextlib import suppress
+from copy import copy
+from pathlib import Path
+
+from covert import passphrase, pubkey, ratchet
+from covert.archive import Archive
+from covert.blockstream import decrypt_file, encrypt_file
+from covert.path import create_datadir, idfilename
+
+
+def create(pwhash, idstore=None):
+  a = Archive()
+  a.index["I"] = idstore or {}
+  # Encrypt in RAM...
+  out = b"".join(b for b in encrypt_file((False, [pwhash], [], []), a.encode, a))
+  create_datadir()
+  # Write the ID file
+  with open(idfilename, "xb") as f:
+    f.write(out)
+
+
+def delete_entire_idstore():
+  """Securely erase the entire idstore. Config folder is removed if empty."""
+  with open(idfilename, "r+b") as f, mmap.mmap(f.fileno(), 0) as m:
+    m[:] = bytes(len(m))
+    os.fsync(f.fileno())
+  idfilename.unlink()
+  with suppress(OSError):
+    idfilename.parent.rmdir()
+
+
+def update(pwhash, allow_create=True, new_pwhash=None):
+  if not new_pwhash:
+    new_pwhash = pwhash
+  if allow_create and not idfilename.exists():
+    idstore = {}
+    yield idstore
+    if idstore: create(new_pwhash, idstore)
+    return
+  with open(idfilename, "r+b") as f, mmap.mmap(f.fileno(), 0) as m:
+    # Decrypt everything to RAM
+    a = Archive()
+    for data in a.decode(decrypt_file([pwhash], m, a)):
+      if isinstance(data, dict):
+        if not "I" in data: data["I"] = dict()
+      elif isinstance(data, bool):
+        if data: a.curfile.data = bytearray()
+      else: a.curfile.data += data
+    # Yield the ID store for operations but do an update even on break/return etc
+    with suppress(GeneratorExit):
+      yield a.index["I"]
+    # Reset archive for re-use in encryption
+    a.reset()
+    a.fds = [BytesIO(f.data) for f in a.flist]
+    a.random_padding(p=0.2)
+    # Encrypt in RAM...
+    out = b"".join(b for b in encrypt_file((False, [new_pwhash], [], []), a.encode, a))
+    # Overwrite the ID file
+    if len(m) < len(out): m.resize(len(out))
+    m[:len(out)] = out
+    if len(m) > 2 * len(out): m.resize(len(m))
+
+def profile(pwhash, idstr, idkey=None, peerkey=None):
+  """Create/update ID profile"""
+  parts = idstr.split(":", 1)
+  local = parts[0]
+  peer = parts[1] if len(parts) == 2 else ""
+  tagself = f"id:{local}"
+  for idstore in update(pwhash):
+    # If no peer given, create a pseudonymous peername
+    while not peer:
+      peer = f".{passphrase.generate(2)}"
+      if f"id:{local}:{peer}" in idstore: peer = None
+    tagpeer = f"id:{local}:{peer}"
+    # Allow using local IDs as peers
+    taglocalpeer = f"id:{peer}"
+    if local == peer or taglocalpeer in idstore:
+      if peerkey: raise ValueError(f"ID {peer} already in store as a local user, cannot have a recipient key specified.")
+    else:
+      taglocalpeer = None
+    if not (taglocalpeer or peerkey or tagpeer in idstore):
+      raise ValueError("Peer not in ID store. You need to specify a recipient public key on the first use.")
+    # Load/generate keys if needed
+    if not idkey:
+      idkey = pubkey.Key(sk=idstore[tagself]["I"]) if tagself in idstore else pubkey.Key()
+    if taglocalpeer:
+      peerkey = idkey if local == peer else pubkey.Key(sk=idstore[taglocalpeer]["I"])
+    elif not peerkey:
+      peerkey = pubkey.Key(pk=idstore[tagpeer]["i"])
+    # Add/update records
+    if tagself not in idstore: idstore[tagself] = dict()
+    if tagpeer not in idstore: idstore[tagpeer] = dict()
+    idstore[tagself]["I"] = idkey.sk
+    idstore[tagpeer]["i"] = peerkey.pk
+    idkey = copy(idkey)
+    peerkey = copy(peerkey)
+    idkey.comment = tagself
+    peerkey.comment = tagpeer
+    r = ratchet.Ratchet()
+    if "r" in idstore[tagpeer]:
+      r.load(idstore[tagpeer]["r"])
+    else:
+      idstore[tagpeer]["r"] = r.store()
+    # These values are not stored in id store but are kept runtime
+    r.tagpeer = tagpeer
+    r.idkey = idkey
+    r.peerkey = peerkey
+  return idkey, peerkey, r
+
+
+def update_ratchet(pwhash, ratch, a):
+  if 'r' in a.index:
+    ratch.prepare_alice(a.filehash[:32], ratch.idkey)
+  for idstore in update(pwhash):
+    idstore[ratch.tagpeer]["r"] = ratch.store()
+
+def save_contact(pwhash, idname, a, b):
+  localkey = b.header.authkey
+  peerkey = a.signatures[0][1]
+  for idstore in update(pwhash):
+    idstore[f"id:{idname}"] = {}
+    idstore[f"id:{idname}"]["i"] = peerkey.pk
+    if "r" in a.index:
+      r = ratchet.Ratchet()
+      r.init_bob(a.filehash[:32], localkey, peerkey)
+      idstore[f"id:{idname}"]["r"] = r.store()
+
+def authgen(pwhash):
+  """Try all authentication keys from the keystore"""
+  for idstore in update(pwhash, allow_create=False):
+    try:
+      for key, value in idstore.items():
+        if "r" in value:
+          r = ratchet.Ratchet()
+          r.load(value['r'])
+          r.idkey = key
+          r.peerkey = pubkey.Key(pk=value['i'])
+          try:
+            yield r
+          except GeneratorExit:
+            # If the ratchet was used, store back with changes
+            value['r'] = r.store()
+            raise
+        if "I" in value: yield pubkey.Key(comment=key, sk=value["I"])
+    except GeneratorExit:
+      break
+
+def idkeys(pwhash):
+  keys = {}
+  for idstore in update(pwhash, allow_create=False):
+    for key, value in idstore.items():
+      if "I" in value:
+        k = pubkey.Key(comment=key, sk=value["I"])
+        keys[k] = k
+      elif "i" in value:
+        k = pubkey.Key(comment=key, pk=value["i"])
+        if k not in keys: keys[k] = k
+  return keys

--- a/covert/passphrase.py
+++ b/covert/passphrase.py
@@ -91,6 +91,7 @@ def autocomplete(pwd, pos):
 
 
 def ask(prompt, create=False):
+  wordcount = 4 if create is True else create
   with fullscreen() as term:
     autohint = ''
     pwd = ''  # nosec
@@ -136,13 +137,13 @@ def ask(prompt, create=False):
         elif ch == "ENTER":
           if valid: return util.encode(pwd), visible
           if create:
-            pwd = generate()
+            pwd = generate(wordcount)
             return util.encode(pwd), True
         elif ch == "ESC":
           visible = not visible
         elif ch == "TAB":
           if create and not pwd:
-            pwd = generate()
+            pwd = generate(wordcount)
             pos = len(pwd)
             visible = True
           else:

--- a/covert/path.py
+++ b/covert/path.py
@@ -1,0 +1,15 @@
+import os
+import subprocess
+
+from xdg import xdg_data_home
+
+datadir = xdg_data_home() / "covert"
+idfilename = datadir / "idstore"
+
+def create_datadir():
+  if not datadir.exists():
+    datadir.mkdir(parents=True)
+    if os.name == "posix":
+      datadir.chmod(0o700)
+      # Attempt to disable CoW (in particular with btrfs and zfs)
+      ret = subprocess.run(["chattr", "+C", datadir], capture_output=True)  # nosec

--- a/covert/ratchet.py
+++ b/covert/ratchet.py
@@ -1,0 +1,211 @@
+import itertools
+from contextlib import suppress
+from time import time
+
+import nacl.bindings as sodium
+from nacl.exceptions import CryptoError
+
+from covert.chacha import decrypt, encrypt
+from covert.pubkey import Key, derive_symkey
+
+MAXSKIP = 20
+
+def expire_soon():
+  return int(time()) + 600  # 10 minutes
+
+def expire_later():
+  return int(time()) + 86400 * 28  # four weeks
+
+def chainstep(chainkey: bytes, addn=b""):
+  """Perform a chaining step, returns (new chainkey, message key)."""
+  h = sodium.crypto_hash_sha512(chainkey + addn)
+  return h[:32], h[32:]
+
+
+class SymChain:
+  def __init__(self):
+    self.CK = None
+    self.HK = None
+    self.NHK = None
+    self.CN = 0
+    self.PN = 0
+    self.N = 0
+
+  def store(self):
+    return dict(
+      CK=self.CK,
+      HK=self.HK,
+      NHK=self.NHK,
+      CN=self.CN,
+      PN=self.PN,
+      N=self.N,
+    )
+
+  def load(self, chain):
+    self.CK = chain['CK']
+    self.HK = chain['HK']
+    self.NHK = chain['NHK']
+    self.CN = chain['CN']
+    self.PN = chain['PN']
+    self.N = chain['N']
+
+  def dhstep(self, ratchet, peerkey):
+    shared = derive_symkey(b"ratchet", ratchet.DH, peerkey)
+    self.CN += self.N
+    self.PN = self.N
+    self.N = 0
+    self.HK = self.NHK
+    ratchet.RK, self.CK = chainstep(ratchet.RK, shared)
+    _, self.NHK = chainstep(ratchet.RK, b"hkey")
+
+  def __next__(self):
+    self.CK, MK = chainstep(self.CK)
+    self.N += 1
+    return MK
+
+class Ratchet:
+  def __init__(self):
+    self.RK = None
+    self.DH = None
+    self.s = SymChain()
+    self.r = SymChain()
+    self.msg = []
+    self.pre = []
+    self.e = expire_later()
+    # Runtime values, not saved
+    self.peerkey = None
+    self.idkey = None
+
+  def store(self):
+    return dict(
+      RK=self.RK,
+      DH=self.DH.sk if self.DH else None,
+      s=self.s.store(),
+      r=self.r.store(),
+      msg=self.msg,
+      pre=self.pre,
+      e=self.e,
+    )
+
+  def load(self, ratchet):
+    self.RK = ratchet['RK']
+    self.DH = Key(sk=ratchet['DH']) if ratchet['DH'] else None
+    self.s.load(ratchet['s'])
+    self.r.load(ratchet['r'])
+    self.msg = ratchet['msg']
+    self.pre = ratchet['pre']
+    self.e = ratchet['e']
+
+  def prepare_alice(self, shared, localkey):
+    """Alice sends non-ratchet initial message."""
+    self.pre.append(shared)
+    self.pre = self.pre[-MAXSKIP:]
+    self.DH = localkey
+    self.s.N += 1
+    self.e = expire_later()
+
+  def init_bob(self, shared, localkey, peerkey):
+    """Bob receives an initial message from Alice, initialise ratchet on Bob side for replies."""
+    self.DH = localkey
+    self.RK = shared
+    self.s.NHK = shared
+    self.dhratchet(peerkey)
+    self.e = expire_later()
+
+  def init_alice(self, ciphertext):
+    """Alice's init when receiving initial ratchet reply from Bob."""
+    for hkey, n in itertools.product(self.pre, range(MAXSKIP)):
+      with suppress(CryptoError):
+        header = decrypt(ciphertext[:50], None, n.to_bytes(12, "little"), hkey)
+        break
+    else:
+      raise CryptoError("No ratchet established, unable to decrypt")
+    self.pre = []
+    self.RK = hkey
+    self.r.NHK = hkey
+    self.s.dhstep(self, self.peerkey)
+    self.dhratchet(Key(pk=header[:32]))
+    self.skip_until(n)
+    self.e = expire_later()
+    return self.readmsg()
+
+  def send(self, peerkey=None):
+    header = encrypt(self.DH.pk + self.s.PN.to_bytes(2, "little"), None, self.s.N.to_bytes(12, "little"), self.s.HK)
+    self.e = expire_later()
+    return header, next(self.s)
+
+  def receive(self, ciphertext):
+    if self.pre:
+      return self.init_alice(ciphertext)
+    # Try skipped keys
+    for s in self.msg:
+      hkey, n = s['H'], s['N']
+      with suppress(CryptoError):
+        header = decrypt(ciphertext[:50], None, n.to_bytes(12, "little"), hkey)
+        s['e'] = expire_soon()
+        s['r'] = True
+        mk = s['M']
+        self.e = expire_later()
+        return mk
+    header = None
+    # Try with current header key
+    if self.r.HK:
+      for n in range(self.r.N, self.r.N + MAXSKIP):
+        with suppress(CryptoError):
+          header = decrypt(ciphertext[:50], None, n.to_bytes(12, "little"), self.r.HK)
+          self.skip_until(n)
+          break
+    # Try with next header key
+    if not header:
+      for n in range(MAXSKIP):
+        with suppress(CryptoError):
+          header = decrypt(ciphertext[:50], None, n.to_bytes(12, "little"), self.r.NHK)
+          PN = int.from_bytes(header[32:34], "little")
+          self.skip_until(PN)
+          self.dhratchet(Key(pk=header[:32]))
+          self.skip_until(n)
+    if not header:
+      raise CryptoError(f"Unable to authenticate")
+    self.e = expire_later()
+    # Advance receiving chain
+    return self.readmsg()
+
+  def dhratchet(self, peerkey):
+    """Perform two DH steps to update all chains."""
+    self.r.dhstep(self, peerkey)
+    self.DH = Key()
+    self.s.dhstep(self, peerkey)
+
+  def skip_until(self, n):
+    """Advance the receiving chain across all messages prior to message n."""
+    while self.r.N < n:
+      self.msg.append(dict(
+        H=self.r.HK,
+        N=self.r.N,
+        M=next(self.r),
+        e=expire_soon(),
+      ))
+
+  def readmsg(self):
+    m = dict(
+      H=self.r.HK,
+      N=self.r.N,
+      M=next(self.r),
+      e=expire_soon(),
+      r=True,
+    )
+    self.msg.append(m)
+    self.msg = self.msg[-MAXSKIP:]
+    return m['M']
+
+
+# Alice sends non-ratchet, includes pk, stores shared secret
+
+# Bob decrypts, calls init_bob, sends ratchet reply nhks=shared
+#  - init RK, recv chain(ii, nhk), new key, send chain(xi)
+
+# Alice receives ratchet reply, shared secret as nhk
+#  - init RK, send chain(ii, nhk),          recv chain(ix), new key, send chain(xx)
+
+# Bob receives reply
+#                                                                  - recv chain(xx), new key, send chain(xx)

--- a/covert/tty.py
+++ b/covert/tty.py
@@ -6,6 +6,20 @@ from contextlib import contextmanager
 from shutil import get_terminal_size
 
 
+@contextmanager
+def status(message):
+  """Write a temporary status message that is cleared once processing is complete."""
+  if sys.stderr.isatty():
+    sys.stderr.write(message)
+    sys.stderr.flush()
+    try:
+      yield
+    finally:
+      sys.stderr.write("\r\x1B[0K")
+      sys.stderr.flush()
+  else:
+    yield
+
 def editor(data=""):
   with fullscreen() as term:
     term.write(f'\x1B[1;1H\x1B[1;44m   〰 ENTER MESSAGE 〰   (ESC to finish)\x1B[0K\x1B[0m\n')

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     "msgpack>=1.0",
     "pyperclip>=1.8",
     "zxcvbn-covert>=5.0.1",
+    "xdg>=5.1.1",
   ],
   extras_require={
     "gui": ["pyside6>=6.2.1", "show-in-file-manager>=1.1.3"],

--- a/tests/test_ratchet.py
+++ b/tests/test_ratchet.py
@@ -1,0 +1,97 @@
+from secrets import token_bytes
+
+import pytest
+from nacl.exceptions import CryptoError
+
+from covert.pubkey import Key
+from covert.ratchet import Ratchet
+
+
+def test_ratchet_pubkey():
+  alice = Key()
+  bob = Key()
+  a = Ratchet()
+  shared = token_bytes()
+  a.peerkey = bob
+  a.prepare_alice(shared, alice)
+
+  b = Ratchet()
+  b.init_bob(shared, bob, alice)
+
+  header1, mkb = b.send()
+  mka = a.receive(header1)
+
+  assert mka == mkb
+  assert b.s.N == 1
+  assert a.r.N == 1
+  assert b.s.HK
+  assert b.s.HK == a.r.HK
+
+  header2, mkb2 = b.send()
+  assert mkb2 != mkb
+
+  header3, mkb3 = b.send()
+  assert mkb3 != mkb2
+
+  # Receive out of order
+  mka3 = a.receive(header3)
+  assert mka3 == mkb3
+
+  mka2 = a.receive(header2)
+  assert mka2 == mkb2
+
+  # Send and receive on current chain (no roundtrip)
+  header4, mkb4 = b.send()
+  header5, mkb5 = b.send()
+  header6, mkb6 = b.send()
+  mka5 = a.receive(header5)
+  assert mka5 == mkb5
+  mka6 = a.receive(header6)
+  assert mka6 == mkb6
+
+
+def test_ratchet_lost_messages():
+  alice = Key()
+  bob = Key()
+  a = Ratchet()
+  shared = [token_bytes(32) for i in range(3)]
+  a.peerkey = bob
+  a.prepare_alice(shared[0], alice)
+  a.prepare_alice(shared[1], alice)
+  a.prepare_alice(shared[2], alice)
+  assert a.s.N == 3
+  assert a.pre == shared
+
+  b = Ratchet()
+  b.init_bob(shared[1], bob, alice)
+
+  header1, mkb1 = b.send()
+  header2, mkb2 = b.send()
+  header3, mkb3 = b.send()
+
+  assert b.s.HK in a.pre
+  assert b.s.N == 3
+
+  mka2 = a.receive(header2)
+
+  assert mka2 == mkb2
+  assert a.r.N == 2
+
+  header4, mkb4 = b.send()
+  assert b.s.N == 4
+
+  mka4 = a.receive(header4)
+  assert mka4 == mkb4
+  assert a.r.N == 4
+
+  # Receive out of order
+  mka3 = a.receive(header3)
+  assert mka3 == mkb3
+
+  # Receive out of order
+  mka1 = a.receive(header1)
+  assert mka1 == mkb1
+
+  # Fail to decode own message
+  with pytest.raises(CryptoError):
+    b.receive(header1)

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,9 @@ commands =
 [testenv]
 usedevelop = true
 extras = test
+setenv =
+  HOME = {envtmpdir}
+  XDG_CONFIG_HOME = {envtmpdir}/confhome
 commands =
   coverage run --append -m pytest {posargs:tests}
 
@@ -35,4 +38,4 @@ commands =
 
 [testenv:security]
 commands =
-  bandit --recursive covert --skip B101
+  bandit --recursive covert --skip B101,B404


### PR DESCRIPTION


A lot of work has gone to a single PR that brings major features and also includes relevant cleanup work. As a side effect, the implementation of signatures has changed and is now incompatible with past versions. The CLI command help was completely redesigned. Covert implements a protocol based on Signal's Double Ratchet with encrypted headers. There may be rough edges here and there, and work on ID store will continue on another PR. Commit log for reference:

* Initial implementation of idstore file where keys can be stored during covert enc.
* Cleanup memoryview and other handles after decryption, avoids mmap closing errors.
* Disable Bandit warning on import subprocess, which is useless because it warns on subprocess calls anyway.
* Add a contextmanager for printing and clearing console messages.
* ID store implemented for covert dec, plenty of cleanup. Use xdg config home for idstore.
* Use tty.status for cleaner code.
* idfilename is now a variable, not a function
* Do not use user HOME dir for tests.
* Fix config dir name
* Make signature block encryption use X25519 keys, avoiding any dependency on Ed25519 and sign errors with that.
* Fix tests for the changed signatures.
* Allow using local IDs as peers. Display unlocking key/id on covert dec.
* Hack to show ID names on signatures.
* Updated signature messages
* Refactor path and configdir handling to covert.path.
* covert id subcommand implemented.
* Fix changed signature message in tests.
* Use XDG datadir instead of config dir for idstore.
* Draft implementation of Signal Double Ratchet for PFS. Not functional yet.
* Ratchet working in principle.
* Fixes and additional tests to ratchet code.
* 100 % coverage on ratchet.
* Some tests for idstore management commands.
* ID store enc/dec tests.
* Double Ratchet with public key handshakes to forward secrecy. Operational but needs more work.
* Change variable name.
* Update specs with general ratchet operation.
* Setting of keys and fixes to covert id subcommand.
* Ratchet info on id command.
* Fix a typo in ratchet store. Print current conversation id in CLI decrypt.
* Ratchet end-to-end tests.
* Increased test coverage, minor fixes.
* Remove example idstore structure from source.
* Addn test
* Rewritten CLI help handling and ID store help.